### PR TITLE
fix: Added env zone to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN mvn -f ./pom.xml clean package
 #
 FROM openjdk:17-oracle
 COPY --from=build ./target/*.jar powerprices.jar
+ENV zone = "NO1"
 ENTRYPOINT ["java","-jar","/powerprices.jar"]


### PR DESCRIPTION
La til en egen env med zone slik at denne kan hentes default. burde også muligens skrive om litt slik at man kan override denne når kotlinkoden kjøres?